### PR TITLE
Resolving Issue 38. https://github.com/splash-cli/splash-cli/issues/38

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
 	},
 	"scripts": {
 		"build": "rm -rf build && npm run test && babel src -d build && npm run copyHTML",
+		"buildW": "rimraf build && npm run test && babel src -d build && npm run copyHTMLW",
 		"copyHTML": "rm -rf build/pages && cp -rf src/pages build",
+		"copyHTMLW": "rimraf build/pages && cp-cli src/pages build",
 		"start": "npm run build && node build/bin/index.js",
+		"startW": "npm run buildW && node build/bin/index.js",
 		"fix": "eslint src/**/*.js --color --fix",
 		"test": "eslint src/**/*.js --color"
 	},
@@ -77,6 +80,8 @@
 		"babel-plugin-transform-regenerator": "^6.26.0",
 		"babel-plugin-transform-runtime": "^6.23.0",
 		"babel-preset-env": "^1.6.1",
-		"eslint": "4.x"
+		"cp-cli": "^2.0.0",
+		"eslint": "4.x",
+		"rimraf": "^2.6.3"
 	}
 }

--- a/src/commands/collection.js
+++ b/src/commands/collection.js
@@ -1,4 +1,3 @@
-import { prompt } from 'inquirer';
 import chalk from 'chalk';
 import tlink from 'terminal-link';
 


### PR DESCRIPTION
CLIENT ID is correctly being passed to unsplash and wallpaper is changing now. 
Added the build support for windows by appending W before every command e.g. npm run buildW will start the build process on windows ( it will work simulteanously on LINUX too, since it use NPM modules which works across different OSes). 


<!-- 
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
    
-->
